### PR TITLE
Fix unintended lifetime elision

### DIFF
--- a/scoped-gc/CHANGELOG.md
+++ b/scoped-gc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Fix]** Fix lifetime elision error on `GcScope::alloc` ([#3](https://github.com/open-flash/rust-scoped-gc/pull/3))
+
 ## 0.1.2 (2018-11-26)
 
 - **[Fix]**: Add `Trace` impl for `BTreeMap`

--- a/scoped-gc/src/gc_scope.rs
+++ b/scoped-gc/src/gc_scope.rs
@@ -22,7 +22,7 @@ impl<'gc> GcScope<'gc> {
   }
 
   /// Allocates `value` in this garbage-collected scope and returns a `Gc` smart pointer to it.
-  pub fn alloc<T: Trace + 'gc>(&self, value: T) -> Result<Gc<T>, GcAllocErr> {
+  pub fn alloc<T: Trace + 'gc>(&self, value: T) -> Result<Gc<'gc, T>, GcAllocErr> {
     unsafe { value.unroot() }
     self.state.borrow_mut()
       .alloc(value)

--- a/scoped-gc/src/test.rs
+++ b/scoped-gc/src/test.rs
@@ -114,3 +114,18 @@ fn test_gc_tree() {
   root.borrow_mut().children.push(Gc::clone(&child2));
   child2.borrow_mut().parent = Some(Gc::clone(&root));
 }
+
+#[test]
+fn test_non_regression_pr3() {
+  // Both functions should compile.
+  {
+    fn _create_gc<'gc>(scope: &GcScope<'gc>) -> Gc<'gc, ()> {
+      scope.alloc(()).unwrap()
+    }
+  }
+  {
+    fn _create_gc<'gc>(scope: &'gc GcScope<'gc>) -> Gc<'gc, ()> {
+      scope.alloc(()).unwrap()
+    }
+  }
+}


### PR DESCRIPTION
Currently, calling `GcScope::alloc` on a reference of `GcScope` requires that the reference live as long as the resulting `Gc`. This should not be the case, as the `Gc`'s lifetime should be tied to the `GcScope` itself, not the reference.

For example, the following does not compile.

```rust 
fn create_gc<'gc>(scope: &GcScope<'gc>) -> Gc<'gc, ()> {
    scope.alloc(()).unwrap()
}
```

However, this does.

```rust 
fn create_gc<'gc>(scope: &'gc GcScope<'gc>) -> Gc<'gc, ()> {
    scope.alloc(()).unwrap()
}
```

This PR fixes this and allows the first example to compile.