### PR TITLE
Remove `generic_param_attrs` feature

### DIFF
--- a/scoped-gc/CHANGELOG.md
+++ b/scoped-gc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Fix]** Fix lifetime elision error on `GcScope::alloc` ([#3](https://github.com/open-flash/rust-scoped-gc/pull/3))
+- **[Fix]** Remove `generic_param_attrs` feature, stable since Rust `1.27.0`.
 
 ## 0.1.2 (2018-11-26)
 

--- a/scoped-gc/src/lib.rs
+++ b/scoped-gc/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(generic_param_attrs)]
 #![feature(dropck_eyepatch)]
 
 /// This module lets you create garbage-collected scopes


### PR DESCRIPTION
The `generic_param_attrs` feature is stable since Rust `1.27.0` so we no longer need to declare it.